### PR TITLE
Reactivate email link for ICT Associate

### DIFF
--- a/_about-us/Team Peicai/Team Peicai.md
+++ b/_about-us/Team Peicai/Team Peicai.md
@@ -1218,7 +1218,8 @@ variant: tiptap
 <p>ICT Associate</p>
 </td>
 <td rowspan="1" colspan="1">
-<p>ong_jun_qi_victor_a@moe.edu.sg</p>
+<p><a href="mailto:ong_jun_qi_victor_a@moe.edu.sg" rel="noopener nofollow" target="_blank">ong_jun_qi_victor_a@moe.edu.sg</a>
+</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
HOD ICT highlighted that ICT Associate's email link was not working